### PR TITLE
Обновление прибалтийских орденов

### DIFF
--- a/history/provinces/1841 - Marienburg.txt
+++ b/history/provinces/1841 - Marienburg.txt
@@ -4,9 +4,9 @@ culture = baltic_prussian
 religion = romuva
 trade_goods = unknown
 hre = no
-base_tax = 2
-base_production = 2
-base_manpower = 2
+base_tax = 4
+base_production = 4
+base_manpower = 3
 discovered_by = eastern
 discovered_by = western
 discovered_by = muslim
@@ -16,28 +16,26 @@ native_ferocity = 4
 native_hostileness = 6
 
 1234.7.1 = {
-	base_tax = 4
-	base_production = 4
-	base_manpower = 3
 	owner = TEU
 	controller = TEU
 	add_core = TEU
-is_city = yes
+	is_city = yes
 	trade_goods = naval_supplies
-	culture = baltic_prussian  
 	religion = catholic
 }
-1242.7.1 = { revolt { type = nationalist_rebels size = 1 }}
-1260.9.1 = { revolt { type = nationalist_rebels size = 1 }}
+1242.7.1 = { revolt = { type = nationalist_rebels size = 1 } controller = REB }
+1249.2.2 = { revolt = {} controller = TEU }
+1260.9.1 = { revolt = { type = nationalist_rebels size = 1 } controller = REB }
+1274.1.1 = { revolt = {} controller = TEU }
 1270.1.1 = {
     capital = "Marienburg"
-    }  
+}  
 1280.1.1 = {
- fort_15th = yes
+	fort_15th = yes
 }
 1301.1.1 = {
-    culture = prussian
-    }
+	culture = prussian
+}
 1454.3.6 = { add_core = POL } # Beginning of the "Thirteen Years War"
 1466.10.19 = {
 	owner = POL

--- a/history/provinces/1841 - Marienburg.txt
+++ b/history/provinces/1841 - Marienburg.txt
@@ -1,26 +1,43 @@
-#Marienburg
 
-owner = TEU
-controller = TEU
-capital = "Marienburg"
-culture = prussian
-religion = catholic
-trade_goods = naval_supplies
+capital = "Rehden"
+culture = baltic_prussian 
+religion = romuva
+trade_goods = unknown
 hre = no
-base_tax = 4
-base_production = 4
-base_manpower = 3
-is_city = yes
-add_core = TEU
-
-
-
+base_tax = 2
+base_production = 2
+base_manpower = 2
 discovered_by = eastern
 discovered_by = western
 discovered_by = muslim
 discovered_by = ottoman
+native_size = 30
+native_ferocity = 4
+native_hostileness = 6
 
-
+1234.7.1 = {
+	base_tax = 4
+	base_production = 4
+	base_manpower = 3
+	owner = TEU
+	controller = TEU
+	add_core = TEU
+is_city = yes
+	trade_goods = naval_supplies
+	culture = baltic_prussian  
+	religion = catholic
+}
+1242.7.1 = { revolt { type = nationalist_rebels size = 1 }}
+1260.9.1 = { revolt { type = nationalist_rebels size = 1 }}
+1270.1.1 = {
+    capital = "Marienburg"
+    }  
+1280.1.1 = {
+ fort_15th = yes
+}
+1301.1.1 = {
+    culture = prussian
+    }
 1454.3.6 = { add_core = POL } # Beginning of the "Thirteen Years War"
 1466.10.19 = {
 	owner = POL

--- a/history/provinces/1842 - Narva.txt
+++ b/history/provinces/1842 - Narva.txt
@@ -1,18 +1,14 @@
 #Narva
 
-owner = LIV
-controller = LIV
-add_core = LIV
-add_core = EST
 culture = estonian
-religion = catholic
+religion = romuva 
 hre = no
-base_tax = 2 
-base_production = 2
-trade_goods = grain
+base_tax = 1
+base_production = 1
+trade_goods = unknown
 base_manpower = 1
 capital = "Narva"
-is_city = yes
+
 discovered_by = KAZ
 discovered_by = CRI
 discovered_by = GOL
@@ -21,7 +17,40 @@ discovered_by = QAS
 discovered_by = western
 discovered_by = eastern
 
-
+1219.1.1 = {
+   	base_tax = 2 
+	base_production = 2
+    base_manpower = 1
+	owner = DAN
+	controller = DAN
+	add_core DAN
+	add_core = EST
+	is_city = yes
+	trade_goods = grain
+	religion = catholic 
+}
+1226.1.1 = {
+   	owner = LIV
+	controller = LIV
+	add_core = LIV
+	add_core DAN
+	add_core = EST
+}
+1236.1.1 = {
+    owner = DAN
+	controller = DAN
+	add_core DAN
+	add_core = LIV
+	add_core = EST
+}
+1343.4.23 = { revolt { type = nationalist_rebels size = 1 } controller = REB} 
+1343.5.5 = { revolt {} controller = DAN }
+1346.1.1 = {
+   	owner = LIV
+	controller = LIV
+	add_core = LIV
+	add_core = EST
+}
 1542.1.1 = { religion = protestant} # Unknown date
 1558.5.11 = {
 	owner = RUS

--- a/history/provinces/1842 - Narva.txt
+++ b/history/provinces/1842 - Narva.txt
@@ -3,10 +3,10 @@
 culture = estonian
 religion = romuva 
 hre = no
-base_tax = 1
-base_production = 1
-trade_goods = unknown
+base_tax = 2 
+base_production = 2
 base_manpower = 1
+trade_goods = unknown
 capital = "Narva"
 
 discovered_by = KAZ
@@ -16,11 +16,11 @@ discovered_by = AST
 discovered_by = QAS
 discovered_by = western
 discovered_by = eastern
+native_size = 30
+native_ferocity = 4
+native_hostileness = 6
 
 1219.1.1 = {
-   	base_tax = 2 
-	base_production = 2
-    base_manpower = 1
 	owner = DAN
 	controller = DAN
 	add_core DAN
@@ -33,23 +33,16 @@ discovered_by = eastern
    	owner = LIV
 	controller = LIV
 	add_core = LIV
-	add_core DAN
-	add_core = EST
 }
 1236.1.1 = {
     owner = DAN
 	controller = DAN
-	add_core DAN
-	add_core = LIV
-	add_core = EST
 }
 1343.4.23 = { revolt { type = nationalist_rebels size = 1 } controller = REB} 
 1343.5.5 = { revolt {} controller = DAN }
 1346.1.1 = {
    	owner = LIV
 	controller = LIV
-	add_core = LIV
-	add_core = EST
 }
 1542.1.1 = { religion = protestant} # Unknown date
 1558.5.11 = {

--- a/history/provinces/1935 - Semigallia.txt
+++ b/history/provinces/1935 - Semigallia.txt
@@ -3,10 +3,10 @@
 culture = latvian
 religion = romuva 
 hre = no
-base_tax = 1
-base_production = 1
+base_tax = 2
+base_production = 2
 trade_goods = unknown
-base_manpower = 1
+base_manpower = 2
 capital = "Mitau"
 
 discovered_by = western
@@ -18,9 +18,6 @@ native_ferocity = 6
 native_hostileness = 4
 
 1250.1.1 = {
-	base_tax = 2 
-	base_production = 2
-	base_manpower = 2
 	owner = LIV
 	controller = LIV
 	add_core = LIV
@@ -31,7 +28,7 @@ native_hostileness = 4
 }
 
 1561.1.1 = {
-    owner = KUR
+	owner = KUR
 	controller = KUR
 	add_core = KUR
 	remove_core = LIV

--- a/history/provinces/1935 - Semigallia.txt
+++ b/history/provinces/1935 - Semigallia.txt
@@ -1,25 +1,37 @@
 #Semigallia, center at Mitau
 
-owner = LIV
-controller = LIV
-add_core = LIV
 culture = latvian
-religion = catholic
+religion = romuva 
 hre = no
-base_tax = 2 
-base_production = 2
-trade_goods = naval_supplies
-base_manpower = 2
+base_tax = 1
+base_production = 1
+trade_goods = unknown
+base_manpower = 1
 capital = "Mitau"
-is_city = yes # Estimated
+
 discovered_by = western
 discovered_by = eastern
 discovered_by = muslim
 discovered_by = ottoman
+native_size = 30
+native_ferocity = 6
+native_hostileness = 4
 
+1250.1.1 = {
+	base_tax = 2 
+	base_production = 2
+	base_manpower = 2
+	owner = LIV
+	controller = LIV
+	add_core = LIV
+	add_core = KUR
+	is_city = yes
+	trade_goods = naval_supplies
+	religion = catholic
+}
 
 1561.1.1 = {
- owner = KUR
+    owner = KUR
 	controller = KUR
 	add_core = KUR
 	remove_core = LIV

--- a/history/provinces/2958 - Osterode.txt
+++ b/history/provinces/2958 - Osterode.txt
@@ -1,27 +1,39 @@
 #2958 - Osterode
 
-owner = TEU
-controller = TEU
 capital = "Osterode"
-culture = prussian
-religion = catholic
-trade_goods = naval_supplies
+culture = baltic_prussian
+religion = romuva
+trade_goods = unknown
 hre = no
-base_tax = 2
-base_production = 2
+base_tax = 1
+base_production = 1
 base_manpower = 1
-is_city = yes
-fort_15th = yes
-add_core = TEU
-
-
+native_size = 30
+native_ferocity = 4
+native_hostileness = 6
 
 discovered_by = eastern
 discovered_by = western
 discovered_by = muslim
 discovered_by = ottoman
 
+1270.1.1 = {
+	base_tax = 2
+	base_production = 2
 
+	owner = TEU
+	controller = TEU
+	add_core = TEU
+remove_core = PRU
+	fort_15th = yes
+is_city = yes
+	trade_goods = naval_supplies
+	culture = baltic_prussian
+	religion = catholic
+}
+1340.1.1 = {
+    culture = prussian
+    }
 1454.3.6 = { add_core = POL revolt = { type = revolutionary_rebels size = 2 } controller = REB } # Beginning of the "thirteen years war"
 1466.10.19 = { revolt = {} controller = TEU add_core = PRU } # "Peace of Torun", became a Polish fief
 1525.2.10 = {

--- a/history/provinces/2958 - Osterode.txt
+++ b/history/provinces/2958 - Osterode.txt
@@ -5,8 +5,8 @@ culture = baltic_prussian
 religion = romuva
 trade_goods = unknown
 hre = no
-base_tax = 1
-base_production = 1
+base_tax = 2
+base_production = 2
 base_manpower = 1
 native_size = 30
 native_ferocity = 4
@@ -18,22 +18,18 @@ discovered_by = muslim
 discovered_by = ottoman
 
 1270.1.1 = {
-	base_tax = 2
-	base_production = 2
-
 	owner = TEU
 	controller = TEU
 	add_core = TEU
-remove_core = PRU
 	fort_15th = yes
-is_city = yes
+	is_city = yes
 	trade_goods = naval_supplies
 	culture = baltic_prussian
 	religion = catholic
 }
 1340.1.1 = {
     culture = prussian
-    }
+}
 1454.3.6 = { add_core = POL revolt = { type = revolutionary_rebels size = 2 } controller = REB } # Beginning of the "thirteen years war"
 1466.10.19 = { revolt = {} controller = TEU add_core = PRU } # "Peace of Torun", became a Polish fief
 1525.2.10 = {

--- a/history/provinces/35 - Osel.txt
+++ b/history/provinces/35 - Osel.txt
@@ -1,9 +1,5 @@
 #Ösel and Dagö, incl. Sonnenburg and Arensburg.
 
-
-
-
-
 culture = estonian
 religion = romuva 
 hre = no
@@ -12,6 +8,9 @@ base_production = 1
 trade_goods = unknown
 base_manpower = 1
 capital = "Arensburg"
+native_size = 30
+native_ferocity = 4
+native_hostileness = 6
 
 
 discovered_by = western
@@ -19,7 +18,7 @@ discovered_by = eastern
 
 
 1227.1.1  = {
-	owner = 
+	owner = RIG
 	controller = RIG
 	add_core = RIG
 	add_core = EST
@@ -27,8 +26,13 @@ discovered_by = eastern
 	trade_goods = grain
 	religion = catholic 
 }
-1344.7.24 = { revolt { type = nationalist_rebels size = 2 } controller = REB} 
-1345.2.14 = { revolt {} controller = RIG }
+1241.1.1  = {
+	owner = LIV
+	controller = LIV
+	add_core = LIV
+}
+1344.7.24 = { revolt { type = nationalist_rebels size = 2 } controller = REB } 
+1345.2.14 = { revolt {} controller = LIV }
 1542.1.1 = { religion = protestant} # Unknown date
 1559.1.1 = {
 	owner = DAN

--- a/history/provinces/35 - Osel.txt
+++ b/history/provinces/35 - Osel.txt
@@ -1,25 +1,34 @@
 #Ösel and Dagö, incl. Sonnenburg and Arensburg.
 
-owner = LIV
-controller = LIV
-add_core = LIV
-add_core = EST
+
+
+
+
 culture = estonian
-religion = catholic
+religion = romuva 
 hre = no
 base_tax = 1 
 base_production = 1
-trade_goods = grain
+trade_goods = unknown
 base_manpower = 1
 capital = "Arensburg"
-is_city = yes
-
 
 
 discovered_by = western
 discovered_by = eastern
 
 
+1227.1.1  = {
+	owner = 
+	controller = RIG
+	add_core = RIG
+	add_core = EST
+	is_city = yes
+	trade_goods = grain
+	religion = catholic 
+}
+1344.7.24 = { revolt { type = nationalist_rebels size = 2 } controller = REB} 
+1345.2.14 = { revolt {} controller = RIG }
 1542.1.1 = { religion = protestant} # Unknown date
 1559.1.1 = {
 	owner = DAN
@@ -41,4 +50,6 @@ discovered_by = eastern
 	add_core = RUS 
 	remove_core = SWE
 } # The Peace of Nystad
+
+
 

--- a/history/provinces/36 - Estland.txt
+++ b/history/provinces/36 - Estland.txt
@@ -1,26 +1,59 @@
 #Estland, incl. Reval, Hapsal, Weissenstein, Wesenberg and Pernau.
 
-owner = LIV
-controller = LIV
-add_core = LIV
-add_core = EST
 culture = estonian
-religion = catholic
+religion = romuva
 hre = no
-base_tax = 4
-base_production = 4
-trade_goods = grain
+base_tax = 2
+base_production = 2
+trade_goods = unknown
 base_manpower = 2
 capital = "Reval"
-is_city = yes
-fort_15th = yes #Fortifications of Reval, Wesenberg, Toompea Castle
 
 
 
 discovered_by = western
 discovered_by = eastern
+native_size = 30
+native_ferocity = 6
+native_hostileness = 4
 
-
+1219.1.1 = {
+	base_tax = 4
+	base_production = 4
+	base_manpower = 2
+	owner = DAN
+	controller = DAN
+	add_core = DAN
+	add_core = EST
+	is_city = yes
+	trade_goods = grain
+	fort_15th = yes #Fortifications of Reval, Wesenberg, Toompea Castle
+	
+	religion = catholic 
+}
+1227.1.1 = {
+	owner = LIV
+	controller = LIV
+	add_core = LIV
+	add_core = DAN
+	add_core = EST
+}
+1236.1.1 = {
+    owner = DAN
+	controller = DAN
+	add_core = DAN
+	add_core = EST
+}
+1250.1.1 = {
+    remove_core = EST
+    }
+1343.4.23 = { revolt { type = nationalist_rebels size = 1 } } 
+1346.1.1 = {
+    owner = LIV
+	controller = LIV
+	add_core = LIV
+	add_core = EST
+}
 1542.1.1 = { religion = protestant} # Unknown date
 1561.1.1 = {
 	owner = SWE
@@ -34,4 +67,5 @@ discovered_by = eastern
 	add_core = RUS
 	remove_core = SWE
 } # The Peace of Nystad
+
 

--- a/history/provinces/36 - Estland.txt
+++ b/history/provinces/36 - Estland.txt
@@ -3,8 +3,8 @@
 culture = estonian
 religion = romuva
 hre = no
-base_tax = 2
-base_production = 2
+base_tax = 4
+base_production = 4
 trade_goods = unknown
 base_manpower = 2
 capital = "Reval"
@@ -18,9 +18,6 @@ native_ferocity = 6
 native_hostileness = 4
 
 1219.1.1 = {
-	base_tax = 4
-	base_production = 4
-	base_manpower = 2
 	owner = DAN
 	controller = DAN
 	add_core = DAN
@@ -28,31 +25,22 @@ native_hostileness = 4
 	is_city = yes
 	trade_goods = grain
 	fort_15th = yes #Fortifications of Reval, Wesenberg, Toompea Castle
-	
 	religion = catholic 
 }
 1227.1.1 = {
 	owner = LIV
 	controller = LIV
 	add_core = LIV
-	add_core = DAN
-	add_core = EST
 }
 1236.1.1 = {
     owner = DAN
 	controller = DAN
-	add_core = DAN
-	add_core = EST
 }
-1250.1.1 = {
-    remove_core = EST
-    }
-1343.4.23 = { revolt { type = nationalist_rebels size = 1 } } 
+1343.4.23 = { revolt { type = nationalist_rebels size = 1 } controller = REB } 
+1343.5.5 = { revolt {} controller = DAN }
 1346.1.1 = {
     owner = LIV
 	controller = LIV
-	add_core = LIV
-	add_core = EST
 }
 1542.1.1 = { religion = protestant} # Unknown date
 1561.1.1 = {

--- a/history/provinces/37 - Livland.txt
+++ b/history/provinces/37 - Livland.txt
@@ -1,22 +1,108 @@
 #273 - Livland
 
-owner = LIV
-controller = LIV
 culture = latvian
-religion = catholic
+religion = romuva 
+capital = "culture = latvian
+religion = romuva 
 capital = "Fellin"
-trade_goods = livestock
+trade_goods = unknown
 hre = no
-base_tax = 3 
-base_production = 3
-base_manpower = 2
-is_city = yes
-add_core = LIV
-add_core = LVA
+base_tax = 2
+base_production = 2
+base_manpower = 1
 discovered_by = western
 discovered_by = eastern
 
 
+
+1212.1.1 = {
+    owner = NOV
+    controller = NOV
+    culture = latvian
+    religion = ortodox
+    capital = "Beverina"
+    trade_goods = livestock
+    hre = no
+    base_tax = 3 
+    base_production = 3
+    base_manpower = 2
+    is_city = yes
+    add_core = NOV
+    add_core = LVA
+}
+1223.1.1 = {
+    owner = LIV
+    controller = LIV
+    culture = latvian
+    religion = catholic
+    capital = "Fellin"
+    add_core = LIV
+    add_core = LVA
+}
+1542.1.1 = { religion = protestant} # Unknown date
+1561.1.1 = {
+	owner = LIT
+	controller = LIT
+	add_core = LIT
+	remove_core = LIV
+} # Livonia ceases to exist
+1569.7.1 = {
+	owner = PLC
+	controller = PLC
+	add_core = PLC
+} # Union of Lublin
+1575.7.1 = { controller = RUS } # Russian conquest
+1582.1.15 = { controller = PLC } # Peace of Jam-Zapolski
+1600.12.31 = { controller = SWE } # 2nd Polish War-Captured by Duke Karl
+1603.4.5 = { controller = PLC } # 2nd Polish War-Captured by Chodkiewicz
+1625.8.21 = { controller = SWE } # 2nd Polish War-Captured by Jakob de la Gardie
+1629.9.16 = {
+	owner = SWE
+	controller = SWE
+	add_core = SWE
+	remove_core = PLC
+}
+1721.8.30 = {
+	owner = RUS
+	controller = RUS
+	add_core = RUS
+	remove_core = SWE
+} # The Peace of Nystad
+Fellin"
+trade_goods = unknown
+hre = no
+base_tax = 2
+base_production = 2
+base_manpower = 1
+discovered_by = western
+discovered_by = eastern
+
+
+
+1212.1.1 = {
+    owner = NOV
+    controller = NOV
+    culture = latvian
+    religion = ortodox
+    capital = "Beverina"
+    trade_goods = livestock
+    hre = no
+    base_tax = 3 
+    base_production = 3
+    base_manpower = 2
+    is_city = yes
+    add_core = NOV
+    add_core = LVA
+}
+1223.1.1 = {
+    owner = LIV
+    controller = LIV
+    culture = latvian
+    religion = catholic
+    capital = "Fellin"
+    add_core = LIV
+    add_core = LVA
+}
 1542.1.1 = { religion = protestant} # Unknown date
 1561.1.1 = {
 	owner = LIT

--- a/history/provinces/37 - Livland.txt
+++ b/history/provinces/37 - Livland.txt
@@ -2,30 +2,27 @@
 
 culture = latvian
 religion = romuva 
-capital = "culture = latvian
+capital = latvian
 religion = romuva 
 capital = "Fellin"
 trade_goods = unknown
 hre = no
-base_tax = 2
-base_production = 2
-base_manpower = 1
+base_tax = 3
+base_production = 3
+base_manpower = 2
 discovered_by = western
 discovered_by = eastern
-
-
+native_size = 30
+native_ferocity = 6
+native_hostileness = 4
 
 1212.1.1 = {
     owner = NOV
     controller = NOV
-    culture = latvian
+    culture = novgorodian
     religion = ortodox
     capital = "Beverina"
     trade_goods = livestock
-    hre = no
-    base_tax = 3 
-    base_production = 3
-    base_manpower = 2
     is_city = yes
     add_core = NOV
     add_core = LVA
@@ -37,7 +34,6 @@ discovered_by = eastern
     religion = catholic
     capital = "Fellin"
     add_core = LIV
-    add_core = LVA
 }
 1542.1.1 = { religion = protestant} # Unknown date
 1561.1.1 = {

--- a/history/provinces/38 - Riga.txt
+++ b/history/provinces/38 - Riga.txt
@@ -1,29 +1,43 @@
 #Riga Bight, incl. the city of Riga, and Dünamünde.
 
-owner = RIG
-controller = RIG
-add_core = RIG
-culture = prussian
-religion = catholic
-hre = no
-base_tax = 5 
-base_production = 5
-trade_goods = naval_supplies
+culture = latvian
+religion = romuva hre = no
+base_tax = 2
+base_production = 2
+trade_goods = unknown
 base_manpower = 1
 capital = "Riga"
-is_city = yes
-fort_15th = yes
-extra_cost = 18
+extra_cost = 8
+
+
 center_of_trade = 1
 
 discovered_by = western
 discovered_by = eastern
 discovered_by = muslim
 discovered_by = ottoman
+native_size = 30
+native_ferocity = 6
+native_hostileness = 4
 
 add_permanent_province_modifier = {
 	name = daugava_estuary_modifier
 	duration = -1
+}
+
+1201.1.1 = {
+	base_tax = 5 
+	base_production = 5
+
+	owner = RIG
+	controller = RIG
+	add_core = RIG
+	add_core = LVA
+	is_city = yes
+	trade_goods = naval_supplies
+	fort_15th = yes
+	culture = prussian
+	religion = catholic 
 }
 
 1522.1.1 = { religion = protestant} # Unknown date

--- a/history/provinces/38 - Riga.txt
+++ b/history/provinces/38 - Riga.txt
@@ -1,9 +1,10 @@
 #Riga Bight, incl. the city of Riga, and Dünamünde.
 
 culture = latvian
-religion = romuva hre = no
-base_tax = 2
-base_production = 2
+religion = romuva 
+hre = no
+base_tax = 5
+base_production = 5
 trade_goods = unknown
 base_manpower = 1
 capital = "Riga"
@@ -26,9 +27,6 @@ add_permanent_province_modifier = {
 }
 
 1201.1.1 = {
-	base_tax = 5 
-	base_production = 5
-
 	owner = RIG
 	controller = RIG
 	add_core = RIG

--- a/history/provinces/39 - Kurland.txt
+++ b/history/provinces/39 - Kurland.txt
@@ -1,17 +1,13 @@
 #Kurland, center at Goldingen
 
-
 culture = latvian
 religion = romuva 
 hre = no
-base_tax = 2
-base_production = 2
+base_tax = 3 
+base_production = 3
 trade_goods = unknown
 base_manpower = 1
 capital = "Goldingen"
-
-
-
 
 discovered_by = western
 discovered_by = eastern
@@ -22,9 +18,6 @@ native_ferocity = 6
 native_hostileness = 4
 
 1230.1.1 = {
-	base_tax = 3
-	base_production = 3
-
 	owner = KUR
 	controller = KUR
 	add_core = KUR
@@ -36,11 +29,11 @@ native_hostileness = 4
     owner = LIV
 	controller = LIV
 	add_core = LIV
-	add_core = KUR
 }
 	
 #1561.11.28
-1561.1.1 = { owner = KUR
+1561.1.1 = { 
+	owner = KUR
 	controller = KUR
 	add_core = KUR
 	remove_core = LIV

--- a/history/provinces/39 - Kurland.txt
+++ b/history/provinces/39 - Kurland.txt
@@ -1,17 +1,15 @@
 #Kurland, center at Goldingen
 
-owner = LIV
-controller = LIV
-add_core = LIV
+
 culture = latvian
-religion = catholic
+religion = romuva 
 hre = no
-base_tax = 3
-base_production = 3
-trade_goods = naval_supplies
+base_tax = 2
+base_production = 2
+trade_goods = unknown
 base_manpower = 1
 capital = "Goldingen"
-is_city = yes
+
 
 
 
@@ -19,8 +17,28 @@ discovered_by = western
 discovered_by = eastern
 discovered_by = muslim
 discovered_by = ottoman
+native_size = 30
+native_ferocity = 6
+native_hostileness = 4
 
+1230.1.1 = {
+	base_tax = 3
+	base_production = 3
 
+	owner = KUR
+	controller = KUR
+	add_core = KUR
+	is_city = yes
+	trade_goods = naval_supplies
+	religion = catholic
+}
+1237.1.1 = {
+    owner = LIV
+	controller = LIV
+	add_core = LIV
+	add_core = KUR
+}
+	
 #1561.11.28
 1561.1.1 = { owner = KUR
 	controller = KUR

--- a/history/provinces/40 - Memel.txt
+++ b/history/provinces/40 - Memel.txt
@@ -1,21 +1,22 @@
 #40 - Memel
 
-owner = TEU
-controller = TEU
+
 culture = lithuanian
-religion = catholic
+religion = romuva
 capital = "Memel"
-trade_goods = livestock
+trade_goods = unknown
 hre = no
-base_tax = 3
-base_production = 3
-base_manpower = 3
-is_city = yes
-add_core = TEU
+base_tax = 2
+base_production = 2
+base_manpower = 2
+
 discovered_by = eastern
 discovered_by = western
 discovered_by = muslim
 discovered_by = ottoman
+native_size = 30
+native_ferocity = 4
+native_hostileness = 6
 
 extra_cost = 10
 
@@ -23,6 +24,24 @@ add_permanent_province_modifier = {
 	name = neman_estuary_modifier
 	duration = -1
 }
+
+
+
+1277.7.1 = {
+	base_tax = 3
+	base_production = 3
+	base_manpower = 3
+	owner = TEU
+	controller = TEU
+	add_core = TEU
+    remove_core = PRU
+    is_city = yes
+	trade_goods = livestock
+	religion = catholic
+}
+1278.1.1 = { revolt { type = nationalist_rebels size = 1 }
+}
+
 
 1454.2.10 = { add_core = POL revolt = { type = revolutionary_rebels size = 0 } controller = REB } # Thirteen years' war
 1466.10.19 = {	revolt = {}
@@ -51,4 +70,5 @@ add_permanent_province_modifier = {
 1750.1.1 = { base_tax = 5 base_production = 5 }
 1757.9.1 = { controller = RUS } # captured by Russia after Gross-Jägersdorf
 1762.1.5 = { controller = PRU } # Russians withdraw
+
 

--- a/history/provinces/40 - Memel.txt
+++ b/history/provinces/40 - Memel.txt
@@ -1,14 +1,13 @@
 #40 - Memel
 
-
 culture = lithuanian
 religion = romuva
 capital = "Memel"
 trade_goods = unknown
 hre = no
-base_tax = 2
-base_production = 2
-base_manpower = 2
+base_tax = 3
+base_production = 3
+base_manpower = 3
 
 discovered_by = eastern
 discovered_by = western
@@ -28,9 +27,6 @@ add_permanent_province_modifier = {
 
 
 1277.7.1 = {
-	base_tax = 3
-	base_production = 3
-	base_manpower = 3
 	owner = TEU
 	controller = TEU
 	add_core = TEU
@@ -39,8 +35,9 @@ add_permanent_province_modifier = {
 	trade_goods = livestock
 	religion = catholic
 }
-1278.1.1 = { revolt { type = nationalist_rebels size = 1 }
-}
+
+1278.1.1 = { revolt = { type = nationalist_rebels size = 1 } controller = REB }
+1283.2.2 = { revolt = {} controller = TEU }
 
 
 1454.2.10 = { add_core = POL revolt = { type = revolutionary_rebels size = 0 } controller = REB } # Thirteen years' war

--- a/history/provinces/41 - Konigsberg.txt
+++ b/history/provinces/41 - Konigsberg.txt
@@ -1,13 +1,13 @@
 #41 - Königsberg
 
-capital = "K?nigsberg"
+capital = "Königsberg"
 culture = baltic_prussian
 religion = romuva
 trade_goods = unknown
 hre = no
-base_tax = 2
-base_production = 2
-base_manpower = 2
+base_tax = 5
+base_production = 5
+base_manpower = 3
 
 discovered_by = eastern
 discovered_by = western
@@ -20,27 +20,22 @@ native_ferocity = 4
 native_hostileness = 6
 
 1255.9.1 = {
-    base_tax = 5
-	base_production = 5
-	base_manpower = 3
 	owner = TEU
 	controller = TEU
 	add_core = TEU
-    add_core = PRU
-    remove_core = PRU
     is_city = yes
 	trade_goods = gems #Amber
 	fort_15th = yes
 	religion = catholic
 }
 
-1260.9.1 = { revolt { type = nationalist_rebels size = 1 }}
-
-1275.6.1 = { revolt { type = nationalist_rebels size = 1 }}
-
+1260.9.1 = { revolt { type = nationalist_rebels size = 1 } controller = REB }
+1274.1.1 = { revolt = {} controller = TEU }
+1275.6.1 = { revolt { type = nationalist_rebels size = 1 } controller = REB }
+1283.2.2 = { revolt = {} controller = TEU }
 1324.1.1 = {
 	culture = prussian
-	}
+}
 1454.3.6 = { add_core = POL revolt = { type = revolutionary_rebels size = 2 } controller = REB } # Beginning of the "thirteen years war"
 1466.10.19 = { revolt = {} controller = TEU add_core = PRU } # "Peace of Torun", became a Polish fief
 1525.2.10 = {

--- a/history/provinces/41 - Konigsberg.txt
+++ b/history/provinces/41 - Konigsberg.txt
@@ -1,26 +1,46 @@
 #41 - Königsberg
 
-owner = TEU
-controller = TEU
-capital = "Königsberg"
-culture = prussian
-religion = catholic
-trade_goods = gems #Amber
+capital = "K?nigsberg"
+culture = baltic_prussian
+religion = romuva
+trade_goods = unknown
 hre = no
-base_tax = 5
-base_production = 5
-base_manpower = 3
-is_city = yes
-fort_15th = yes
-add_core = TEU
+base_tax = 2
+base_production = 2
+base_manpower = 2
+
 discovered_by = eastern
 discovered_by = western
 discovered_by = muslim
 discovered_by = ottoman
 extra_cost = 8
 center_of_trade = 1
+native_size = 30
+native_ferocity = 4
+native_hostileness = 6
 
+1255.9.1 = {
+    base_tax = 5
+	base_production = 5
+	base_manpower = 3
+	owner = TEU
+	controller = TEU
+	add_core = TEU
+    add_core = PRU
+    remove_core = PRU
+    is_city = yes
+	trade_goods = gems #Amber
+	fort_15th = yes
+	religion = catholic
+}
 
+1260.9.1 = { revolt { type = nationalist_rebels size = 1 }}
+
+1275.6.1 = { revolt { type = nationalist_rebels size = 1 }}
+
+1324.1.1 = {
+	culture = prussian
+	}
 1454.3.6 = { add_core = POL revolt = { type = revolutionary_rebels size = 2 } controller = REB } # Beginning of the "thirteen years war"
 1466.10.19 = { revolt = {} controller = TEU add_core = PRU } # "Peace of Torun", became a Polish fief
 1525.2.10 = {

--- a/history/provinces/42 - Warmia.txt
+++ b/history/provinces/42 - Warmia.txt
@@ -5,9 +5,9 @@ culture = baltic_prussian
 religion = romuva
 trade_goods = unknown
 hre = no
-base_tax = 2
-base_production = 2
-base_manpower = 1
+base_tax = 3
+base_production = 3
+base_manpower = 2
 
 native_size = 30
 native_ferocity = 4
@@ -19,27 +19,20 @@ discovered_by = muslim
 discovered_by = ottoman
 
 1240.1.1 = {
-	base_tax = 3
-	base_production = 3
-	base_manpower = 2
 	owner = TEU
 	controller = TEU
 	add_core = TEU
-remove_core = PRU
-is_city = yes
+	is_city = yes
 	trade_goods = naval_supplies
-	culture = baltic_prussian
 	religion = catholic
 }
-1242.7.1 = { revolt { type = nationalist_rebels size = 1 }}
-1260.9.1 = { revolt { type = nationalist_rebels size = 1 } controller = REB
-}
-1264.9.1 = { 
-    controller = TEU
-    }
+1242.7.1 = { revolt { type = nationalist_rebels size = 1 } controller = REB }
+1249.2.2 = { revolt = {} controller = TEU }
+1260.9.1 = { revolt { type = nationalist_rebels size = 1 } controller = REB }
+1264.9.1 = { revolt = {} controller = TEU }
 1314.9.1 = {
     culture = prussian
-    }
+}
 1454.3.6 = { add_core = POL } # Beginning of the "thirteen years war"
 1466.10.19 = {
 	owner = POL

--- a/history/provinces/42 - Warmia.txt
+++ b/history/provinces/42 - Warmia.txt
@@ -1,26 +1,45 @@
 #42 - Warmia
 
-owner = TEU
-controller = TEU
 capital = "Allenstein"
-culture = prussian
-religion = catholic
-trade_goods = naval_supplies
+culture = baltic_prussian
+religion = romuva
+trade_goods = unknown
 hre = no
-base_tax = 3
-base_production = 3
-base_manpower = 2
-is_city = yes
-add_core = TEU
+base_tax = 2
+base_production = 2
+base_manpower = 1
 
-
+native_size = 30
+native_ferocity = 4
+native_hostileness = 6
 
 discovered_by = eastern
 discovered_by = western
 discovered_by = muslim
 discovered_by = ottoman
 
-
+1240.1.1 = {
+	base_tax = 3
+	base_production = 3
+	base_manpower = 2
+	owner = TEU
+	controller = TEU
+	add_core = TEU
+remove_core = PRU
+is_city = yes
+	trade_goods = naval_supplies
+	culture = baltic_prussian
+	religion = catholic
+}
+1242.7.1 = { revolt { type = nationalist_rebels size = 1 }}
+1260.9.1 = { revolt { type = nationalist_rebels size = 1 } controller = REB
+}
+1264.9.1 = { 
+    controller = TEU
+    }
+1314.9.1 = {
+    culture = prussian
+    }
 1454.3.6 = { add_core = POL } # Beginning of the "thirteen years war"
 1466.10.19 = {
 	owner = POL

--- a/history/provinces/767 - Ortelsburg.txt
+++ b/history/provinces/767 - Ortelsburg.txt
@@ -6,9 +6,9 @@ culture = baltic_prussian
 religion = romuva
 trade_goods = unknown
 hre = no
-base_tax = 1
-base_production = 1
-base_manpower = 1
+base_tax = 2
+base_production = 2
+base_manpower = 2
 
 discovered_by = eastern
 discovered_by = western
@@ -20,33 +20,22 @@ native_ferocity = 4
 native_hostileness = 6
 
 1252.7.1 = { 
-    base_tax = 2
-	base_production = 2
-	base_manpower = 2
 	owner = TEU
 	controller = TEU
 	add_core = TEU
-    remove_core = PRU
     is_city = yes
 	trade_goods = naval_supplies
-	culture = baltic_prussian
 	religion = catholic
 }
 
-
-1260.9.1 = { revolt { type = nationalist_rebels size = 1 }
-}
-
-1264.9.1 = { controller = REB
-}
-1273.7.1 = { controller = TEU 
-}
+1264.9.1 = { revolt = { type = nationalist_rebels size = 1 } controller = REB }
+1273.7.1 = { revolt = {} controller = TEU }
 1323.7.1 = {
 	culture = prussian
-	}
+}
 1349.1.1 = { 
-    capital = Ortelsburg
-    }
+    capital = "Ortelsburg"
+}
 1454.3.6 = { add_core = POL revolt = { type = revolutionary_rebels size = 2 } controller = REB } # Beginning of the "thirteen years war"
 1466.10.19 = { revolt = {} controller = TEU add_core = PRU } # "Peace of Torun", became a Polish fief
 1525.2.10 = {

--- a/history/provinces/767 - Ortelsburg.txt
+++ b/history/provinces/767 - Ortelsburg.txt
@@ -1,22 +1,52 @@
 # - Ortelsburg
 
-owner = TEU
-controller = TEU
-capital = "Ortelsburg"
-culture = prussian
-religion = catholic
-trade_goods = naval_supplies
+
+capital = "Bartenstein"
+culture = baltic_prussian
+religion = romuva
+trade_goods = unknown
 hre = no
-base_tax = 2
-base_production = 2
-base_manpower = 2
-is_city = yes
-add_core = TEU
+base_tax = 1
+base_production = 1
+base_manpower = 1
+
 discovered_by = eastern
 discovered_by = western
 discovered_by = muslim
 discovered_by = ottoman
 
+native_size = 30
+native_ferocity = 4
+native_hostileness = 6
+
+1252.7.1 = { 
+    base_tax = 2
+	base_production = 2
+	base_manpower = 2
+	owner = TEU
+	controller = TEU
+	add_core = TEU
+    remove_core = PRU
+    is_city = yes
+	trade_goods = naval_supplies
+	culture = baltic_prussian
+	religion = catholic
+}
+
+
+1260.9.1 = { revolt { type = nationalist_rebels size = 1 }
+}
+
+1264.9.1 = { controller = REB
+}
+1273.7.1 = { controller = TEU 
+}
+1323.7.1 = {
+	culture = prussian
+	}
+1349.1.1 = { 
+    capital = Ortelsburg
+    }
 1454.3.6 = { add_core = POL revolt = { type = revolutionary_rebels size = 2 } controller = REB } # Beginning of the "thirteen years war"
 1466.10.19 = { revolt = {} controller = TEU add_core = PRU } # "Peace of Torun", became a Polish fief
 1525.2.10 = {


### PR DESCRIPTION
Изменения в истории балтийских орденов.  (кроме  Torun, Dorpat, Wenden и частично Osel)